### PR TITLE
Switching from modified date to checksum for comparing files.

### DIFF
--- a/CinderBlockGames.GitHub.Actions.Ftp/Item.cs
+++ b/CinderBlockGames.GitHub.Actions.Ftp/Item.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace CinderBlockGames.GitHub.Actions.Ftp
+﻿namespace CinderBlockGames.GitHub.Actions.Ftp
 {
     internal class Item
     {
@@ -9,13 +7,11 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
         public string LocalPath { get; set; }
         public string Directory { get; set; }
         public string Name { get; set; }
-        public DateTime Modified { get; set; }
 
-        public Item(string filename, string originalPath, DateTime modified)
+        public Item(string filename, string originalPath)
         {
             FullPath = Standardize(filename);
             LocalPath = FullPath.Substring(originalPath.Length).TrimStart('/');
-            Modified = modified;
 
             var split = LocalPath.LastIndexOf('/');
             if (split > 0)

--- a/CinderBlockGames.GitHub.Actions.Ftp/Options.cs
+++ b/CinderBlockGames.GitHub.Actions.Ftp/Options.cs
@@ -41,10 +41,10 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
 
         // Options.
 
-        [Option("ignoreUnchanged",
+        [Option("skipUnchanged",
                 Required = false, Default = false,
                 HelpText = "Do not upload any file that hasn't changed.  Setting to true will be slower than leaving false.")]
-        public bool IgnoreUnchanged { get; set; }
+        public bool? SkipUnchanged { get; set; }
 
     }
 }

--- a/CinderBlockGames.GitHub.Actions.Ftp/Options.cs
+++ b/CinderBlockGames.GitHub.Actions.Ftp/Options.cs
@@ -39,5 +39,12 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
                 HelpText = "Directory in destination to which to upload.")]
         public string DestinationPath { get; set; }
 
+        // Options.
+
+        [Option("ignoreUnchanged",
+                Required = false, Default = false,
+                HelpText = "Do not upload any file that hasn't changed.  Setting to true will be slower than leaving false.")]
+        public bool IgnoreUnchanged { get; set; }
+
     }
 }

--- a/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
+++ b/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
@@ -21,7 +21,7 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
             // Get source files info.
             Console.WriteLine("...Finding source files...");
             var source = Directory.GetFiles(options.SourcePath, "*", SearchOption.AllDirectories)
-                                  .Select(src => new Item(src, options.SourcePath, File.GetLastWriteTime(src).ToUniversalTime()));
+                                  .Select(src => new Item(src, options.SourcePath, File.GetLastWriteTime(src)));
 
             using (var client = new FtpClient(options.Server, options.Port, options.Username, options.Password))
             {

--- a/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
+++ b/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
@@ -21,7 +21,7 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
             // Get source files info.
             Console.WriteLine("...Finding source files...");
             var source = Directory.GetFiles(options.SourcePath, "*", SearchOption.AllDirectories)
-                                  .Select(src => new Item(src, options.SourcePath, File.GetLastWriteTime(src)));
+                                  .Select(src => new Item(src, options.SourcePath, File.GetLastWriteTime(src).ToUniversalTime()));
 
             using (var client = new FtpClient(options.Server, options.Port, options.Username, options.Password))
             {

--- a/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
+++ b/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
@@ -63,7 +63,7 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
                             {
                                 if (client.Download(dest, pair.dest.FullPath))
                                 {
-                                    var hash = algo.ComputeHash(dest);
+                                    IEnumerable<byte> hash = algo.ComputeHash(dest);
                                     using (var src = File.OpenRead(pair.src.FullPath))
                                     {
                                         if (!hash.SequenceEqual(algo.ComputeHash(src)))

--- a/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
+++ b/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
@@ -50,7 +50,7 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
 
                 #endregion
 
-                if (options.IgnoreUnchanged)
+                if (options.SkipUnchanged == true)
                 {
                     #region " Update "
 

--- a/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
+++ b/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
@@ -49,7 +49,7 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
                               from dest in destination
                               where ItemComparer.Default.Equals(src, dest)
                               let hash = client.GetChecksum(dest.FullPath)
-                              where !hash.Verify(src.FullPath)
+                              where hash.IsValid && !hash.Verify(src.FullPath)
                               select src);
                 Console.WriteLine($"...Updating {update.Count()} files...");
                 Upload(client, update);

--- a/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
+++ b/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
@@ -46,6 +46,7 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
                 Console.WriteLine();
 
                 // Update any files that have changed.
+                Console.WriteLine("...Checking files for updates...");
                 IEnumerable<Item> update = null;
                 if (client.HashAlgorithms == FtpHashAlgorithm.NONE)
                 {
@@ -65,7 +66,7 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
                                     var hash = algo.ComputeHash(dest);
                                     using (var src = File.OpenRead(pair.src.FullPath))
                                     {
-                                        if (hash.SequenceEqual(algo.ComputeHash(src)))
+                                        if (!hash.SequenceEqual(algo.ComputeHash(src)))
                                         {
                                             list.Add(pair.src);
                                         }

--- a/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
+++ b/CinderBlockGames.GitHub.Actions.Ftp/Program.cs
@@ -36,6 +36,8 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
                                         .Where(dest => dest.Type == FtpFileSystemObjectType.File)
                                         .Select(dest => new Item(dest.FullName, options.DestinationPath));
 
+                #region " Delete "
+
                 // Delete any files that don't exist in source.
                 var delete = destination.Except(source, ItemComparer.Default);
                 Console.WriteLine($"...Deleting {delete.Count()} files...");
@@ -46,12 +48,15 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
                 }
                 Console.WriteLine();
 
-                // Update any files that have changed.
-                Console.WriteLine("...Checking files for updates...");
-                IEnumerable<Item> update = null;
-                if (client.HashAlgorithms == FtpHashAlgorithm.NONE)
+                #endregion
+
+                if (options.IgnoreUnchanged)
                 {
-                    var list = new List<Item>();
+                    #region " Update "
+
+                    // Update any files that have changed.
+                    Console.WriteLine("...Checking files for updates...");
+                    var update = new List<Item>();
                     var existing = (from src in source
                                     from dest in destination
                                     where ItemComparer.Default.Equals(src, dest)
@@ -65,37 +70,43 @@ namespace CinderBlockGames.GitHub.Actions.Ftp
                             if (client.DownloadFile(filename, pair.dest.FullPath) == FtpStatus.Success)
                             {
                                 var dest = File.ReadAllText(filename)
-                                               .Replace("\r\n", "\n").Replace("\r", "\n"); // Standardize line endings.
+                                                .Replace("\r\n", "\n").Replace("\r", "\n"); // Standardize line endings.
                                 IEnumerable<byte> hash = algo.ComputeHash(encoding.GetBytes(dest));
                                 var src = File.ReadAllText(pair.src.FullPath)
-                                              .Replace("\r\n", "\n").Replace("\r", "\n"); // Standardize line endings.;
+                                                .Replace("\r\n", "\n").Replace("\r", "\n"); // Standardize line endings.
                                 if (!hash.SequenceEqual(algo.ComputeHash(encoding.GetBytes(src))))
                                 {
-                                    list.Add(pair.src);
+                                    update.Add(pair.src);
                                 }
                             }
                         }
                     }
-                    update = list;
+                    Console.WriteLine($"...Updating {update.Count()} files...");
+                    Upload(client, update);
+                    Console.WriteLine();
+
+                    #endregion
+
+                    #region " Insert "
+
+                    // Upload any files that are new.
+                    var upload = source.Except(destination, ItemComparer.Default);
+                    Console.WriteLine($"...Uploading {upload.Count()} new files...");
+                    Upload(client, upload);
+                    Console.WriteLine();
+
+                    #endregion
                 }
                 else
                 {
-                    update = (from src in source
-                              from dest in destination
-                              where ItemComparer.Default.Equals(src, dest)
-                              let hash = client.GetChecksum(dest.FullPath)
-                              where hash.IsValid && !hash.Verify(src.FullPath)
-                              select src);
+                    #region " Upsert "
+
+                    Console.WriteLine($"...Uploading {source.Count()} files...");
+                    Upload(client, source);
+                    Console.WriteLine();
+
+                    #endregion
                 }
-                Console.WriteLine($"...Updating {update.Count()} files...");
-                Upload(client, update);
-                Console.WriteLine();
-                
-                // Upload any files that are new.
-                var upload = source.Except(destination, ItemComparer.Default);
-                Console.WriteLine($"...Uploading {upload.Count()} new files...");
-                Upload(client, upload);
-                Console.WriteLine();
 
                 Console.WriteLine("Complete!");
             }

--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
 # FTP Smart File Copy
 This .NET-based GitHub Action updates the destination to match the source over FTP, by executing the following steps:
 - Delete files from destination that do not exist in source.
-- Update files that have been modified in source since they were last modified in destination.
-- Upload files from source that do not exist in destination.
+- ignoreUnchanged?
+  - true
+    - Update files that have been modified in source since they were last modified in destination.
+    - Upload files from source that do not exist in destination.
+  - false
+    - Upload all files from source to destination.
 
 ## Inputs
-| Parameter   | Required  | Default | Description                                  |
-| ----------- | --------- | ------- | -------------------------------------------- |
-| server      | **Yes**   |         | Address for the destination server.          |
-| port        | No        | **21**  | Port for the destination server.             |
-| username    | **Yes**   |         | Username for the destination server.         |
-| password    | **Yes**   |         | Password for the destination server.         |
-| source      | No        | **/**   | Directory in source from which to upload.    |
-| destination | No        | **/**   | Directory in destination to which to upload. |
+| Parameter       | Required  | Default     | Description                                                                                     |
+| --------------- | --------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| server          | **Yes**   |             | Address for the destination server.                                                             |
+| port            | No        | **21**      | Port for the destination server.                                                                |
+| username        | **Yes**   |             | Username for the destination server.                                                            |
+| password        | **Yes**   |             | Password for the destination server.                                                            |
+| source          | No        | **/**       | Directory in source from which to upload.                                                       |
+| destination     | No        | **/**       | Directory in destination to which to upload.                                                    |
+| ignoreUnchanged | No        | **false**   | Do not upload any file that hasn't changed.  Setting to true will be slower than leaving false. |
 
 ## Example Workflow
 ```
@@ -47,4 +52,5 @@ jobs:
         port: 22
         source: src/path
         destination: target/path
+        ignoreUnchanged: true
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This .NET-based GitHub Action updates the destination to match the source over F
 | **password**  | **Yes**   |           | Password for the destination server.         |
 | source        | No        | **/**     | Directory in source from which to upload.    |
 | destination   | No        | **/**     | Directory in destination to which to upload. |
-| skipUnchanged | No        | **false** | Do not upload any file that hasn't changed.  |
+| skipUnchanged | No        | **false** | Only upload files that have changed.         |
 
 ## Example Workflow
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This .NET-based GitHub Action updates the destination to match the source over F
 - Delete files from destination that do not exist in source.
 - ignoreUnchanged?
   - true
-    - Update files that have been modified in source since they were last modified in destination.
+    - Update files that do not match between source and destination.
     - Upload files from source that do not exist in destination.
   - false
     - Upload all files from source to destination.
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v2.3.4
       
     - name: FTP Deploy
-      uses: cinderblockgames/ftp-action@v1.0.1
+      uses: cinderblockgames/ftp-action@v1.1.0
       with:
         # required
         server: ftp.example.com

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ This .NET-based GitHub Action updates the destination to match the source over F
 
 ## Inputs
 | Parameter     | Required  | Default   | Description                                                                                     |
-| ------------- | --------- | --------- | ----------------------------------------------------------------------------------------------- |
-| **server**    | **Yes**   |           | Address for the destination server.                                                             |
-| port          | No        | **21**    | Port for the destination server.                                                                |
-| **username**  | **Yes**   |           | Username for the destination server.                                                            |
-| **password**  | **Yes**   |           | Password for the destination server.                                                            |
-| source        | No        | **/**     | Directory in source from which to upload.                                                       |
-| destination   | No        | **/**     | Directory in destination to which to upload.                                                    |
-| skipUnchanged | No        | **false** | Do not upload any file that hasn't changed.  Setting to true will be slower than leaving false. |
+| ------------- | --------- | --------- | -------------------------------------------- |
+| **server**    | **Yes**   |           | Address for the destination server.          |
+| port          | No        | **21**    | Port for the destination server.             |
+| **username**  | **Yes**   |           | Username for the destination server.         |
+| **password**  | **Yes**   |           | Password for the destination server.         |
+| source        | No        | **/**     | Directory in source from which to upload.    |
+| destination   | No        | **/**     | Directory in destination to which to upload. |
+| skipUnchanged | No        | **false** | Do not upload any file that hasn't changed.  |
 
 ## Example Workflow
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FTP Smart File Copy
 This .NET-based GitHub Action updates the destination to match the source over FTP, by executing the following steps:
 - Delete files from destination that do not exist in source.
-- ignoreUnchanged?
+- skipUnchanged?
   - true
     - Update files that do not match between source and destination.
     - Upload files from source that do not exist in destination.
@@ -9,15 +9,15 @@ This .NET-based GitHub Action updates the destination to match the source over F
     - Upload all files from source to destination.
 
 ## Inputs
-| Parameter       | Required  | Default     | Description                                                                                     |
-| --------------- | --------- | ----------- | ----------------------------------------------------------------------------------------------- |
-| server          | **Yes**   |             | Address for the destination server.                                                             |
-| port            | No        | **21**      | Port for the destination server.                                                                |
-| username        | **Yes**   |             | Username for the destination server.                                                            |
-| password        | **Yes**   |             | Password for the destination server.                                                            |
-| source          | No        | **/**       | Directory in source from which to upload.                                                       |
-| destination     | No        | **/**       | Directory in destination to which to upload.                                                    |
-| ignoreUnchanged | No        | **false**   | Do not upload any file that hasn't changed.  Setting to true will be slower than leaving false. |
+| Parameter     | Required  | Default   | Description                                                                                     |
+| ------------- | --------- | --------- | ----------------------------------------------------------------------------------------------- |
+| **server**    | **Yes**   |           | Address for the destination server.                                                             |
+| port          | No        | **21**    | Port for the destination server.                                                                |
+| **username**  | **Yes**   |           | Username for the destination server.                                                            |
+| **password**  | **Yes**   |           | Password for the destination server.                                                            |
+| source        | No        | **/**     | Directory in source from which to upload.                                                       |
+| destination   | No        | **/**     | Directory in destination to which to upload.                                                    |
+| skipUnchanged | No        | **false** | Do not upload any file that hasn't changed.  Setting to true will be slower than leaving false. |
 
 ## Example Workflow
 ```
@@ -52,5 +52,5 @@ jobs:
         port: 22
         source: src/path
         destination: target/path
-        ignoreUnchanged: true
+        skipUnchanged: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
       'Directory in destination to which to upload.'
     required: true
     default: '/'
-  ignoreUnchanged:
+  skipUnchanged:
     description:
       'Do not upload any file that hasn''t changed.  Setting to true will be slower than leaving false.'
     required: false
@@ -52,5 +52,5 @@ runs:
   - ${{ inputs.source }}
   - '--destination'
   - ${{ inputs.destination }}
-  - '--ignoreUnchanged'
-  - ${{ inputs.ignoreUnchanged }}
+  - '--skipUnchanged'
+  - ${{ inputs.skipUnchanged }}

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description:
       'Port for the destination server.'
     required: false
-    default: 21
+    default: '21'
   username:
     description:
       'Username for the destination server.'
@@ -31,6 +31,11 @@ inputs:
       'Directory in destination to which to upload.'
     required: true
     default: '/'
+  ignoreUnchanged:
+    description:
+      'Do not upload any file that hasn''t changed.  Setting to true will be slower than leaving false.'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -47,3 +52,5 @@ runs:
   - ${{ inputs.source }}
   - '--destination'
   - ${{ inputs.destination }}
+  - '--ignoreUnchanged'
+  - ${{ inputs.ignoreUnchanged }}


### PR DESCRIPTION
- Resolves the issue where all files are uploaded no matter what.
  - Turns out, copying the files to the container means losing any modified date data -- which GitHub doesn't track anyway.
- Also added a skipUnchanged flag for controlling whether to upload all (false) or just changed (true) files.
  - Let the user control how they want the upload to work.